### PR TITLE
(fix) Allow initializing segment natively on Android

### DIFF
--- a/android/src/main/java/com/smore/RNSegmentIOAnalytics/RNSegmentIOAnalyticsModule.java
+++ b/android/src/main/java/com/smore/RNSegmentIOAnalytics/RNSegmentIOAnalyticsModule.java
@@ -29,8 +29,9 @@ public class RNSegmentIOAnalyticsModule extends ReactContextBaseJavaModule {
     Log.d("RNSegmentIOAnalytics", message);
   }
 
-  public RNSegmentIOAnalyticsModule(ReactApplicationContext reactContext) {
+  public RNSegmentIOAnalyticsModule(ReactApplicationContext reactContext, Analytics analytics) {
     super(reactContext);
+    mAnalytics = analytics;
   }
 
   /*

--- a/android/src/main/java/com/smore/RNSegmentIOAnalytics/RNSegmentIOAnalyticsModule.java
+++ b/android/src/main/java/com/smore/RNSegmentIOAnalytics/RNSegmentIOAnalyticsModule.java
@@ -38,14 +38,11 @@ public class RNSegmentIOAnalyticsModule extends ReactContextBaseJavaModule {
    https://segment.com/docs/libraries/android/#identify
    */
   @ReactMethod
-  public void setup(String writeKey, Integer flushAt, Boolean shouldUseLocationServices, ReadableMap options) {
+  public void setup(String writeKey, Integer flushAt, Boolean shouldUseLocationServices) {
     if (mAnalytics == null) {
       Context context = getReactApplicationContext().getApplicationContext();
       Builder builder = new Analytics.Builder(context, writeKey);
       builder.flushQueueSize(flushAt);
-      if (options.getBoolean("trackApplicationLifecycleEvents")) {
-        builder.trackApplicationLifecycleEvents();
-      }
 
       if (mDebug) {
         builder.logLevel(Analytics.LogLevel.DEBUG);

--- a/android/src/main/java/com/smore/RNSegmentIOAnalytics/RNSegmentIOAnalyticsPackage.java
+++ b/android/src/main/java/com/smore/RNSegmentIOAnalytics/RNSegmentIOAnalyticsPackage.java
@@ -1,5 +1,6 @@
 package com.smore.RNSegmentIOAnalytics;
 
+import com.segment.analytics.Analytics;
 import com.smore.RNSegmentIOAnalytics.RNSegmentIOAnalyticsModule;
 import com.facebook.react.ReactPackage;
 import com.facebook.react.bridge.NativeModule;

--- a/android/src/main/java/com/smore/RNSegmentIOAnalytics/RNSegmentIOAnalyticsPackage.java
+++ b/android/src/main/java/com/smore/RNSegmentIOAnalytics/RNSegmentIOAnalyticsPackage.java
@@ -13,6 +13,16 @@ import java.util.ArrayList;
 import java.util.Collections;
 
 public class RNSegmentIOAnalyticsPackage implements ReactPackage {
+  private static Analytics mAnalytics;
+
+  public RNSegmentIOAnalyticsPackage() {
+    mAnalytics = null;
+  }
+
+  public RNSegmentIOAnalyticsPackage(Analytics analytics) {
+    mAnalytics = analytics;
+  }
+
   @Override
   public List<NativeModule> createNativeModules(
                               ReactApplicationContext reactContext) {
@@ -21,7 +31,7 @@ public class RNSegmentIOAnalyticsPackage implements ReactPackage {
 
     List<NativeModule> modules = new ArrayList<>();
 
-    modules.add(new RNSegmentIOAnalyticsModule(reactContext));
+    modules.add(new RNSegmentIOAnalyticsModule(reactContext, mAnalytics));
 
     return modules;
   }

--- a/android/src/main/java/com/smore/RNSegmentIOAnalytics/RNSegmentIOAnalyticsPackage.java
+++ b/android/src/main/java/com/smore/RNSegmentIOAnalytics/RNSegmentIOAnalyticsPackage.java
@@ -14,7 +14,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 
 public class RNSegmentIOAnalyticsPackage implements ReactPackage {
-  private static Analytics mAnalytics;
+  private final Analytics mAnalytics;
 
   public RNSegmentIOAnalyticsPackage() {
     mAnalytics = null;

--- a/index.js
+++ b/index.js
@@ -25,8 +25,8 @@ export default {
      * @param flushAt https://segment.com/docs/libraries/ios/#flushing or https://segment.com/docs/libraries/android/#customizing-the-client
      * @param shouldUseLocationServices https://segment.com/docs/libraries/ios/#location-services
      */
-    setup: function (configKey: string, flushAt: number = 20, shouldUseLocationServices: bool = false, options: ?Object = {}) {
-        NativeRNSegmentIOAnalytics.setup(configKey, flushAt, shouldUseLocationServices, options)
+    setup: function (configKey: string, flushAt: number = 20, shouldUseLocationServices: bool = false) {
+        NativeRNSegmentIOAnalytics.setup(configKey, flushAt, shouldUseLocationServices)
     },
 
     /*

--- a/ios/RNAnalytics/RNSegmentIOAnalytics.m
+++ b/ios/RNAnalytics/RNSegmentIOAnalytics.m
@@ -14,12 +14,11 @@
 
 RCT_EXPORT_MODULE()
 
-RCT_EXPORT_METHOD(setup:(NSString*)configKey :(NSUInteger)flushAt :(BOOL)shouldUseLocationServices :(NSDictionary *)options)
+RCT_EXPORT_METHOD(setup:(NSString*)configKey :(NSUInteger)flushAt :(BOOL)shouldUseLocationServices)
 {
     SEGAnalyticsConfiguration *configuration = [SEGAnalyticsConfiguration configurationWithWriteKey:configKey];
     configuration.flushAt = flushAt;
     configuration.shouldUseLocationServices = shouldUseLocationServices;
-    configuration.trackApplicationLifecycleEvents = options[@"trackApplicationLifecycleEvents"];
     [SEGAnalytics setupWithConfiguration:configuration];
 }
 


### PR DESCRIPTION
## Link to story (or tech task)

https://app.clubhouse.io/everymed/story/11273/application-installed-event-firing-inconsistently-on-android

## Description

- [x] Allow initialising Segment `analytics` instance in native code on Android (iOS had no problems with it)
- [x] Revert previous fix, because it doesn't solve the problem it was intended to solve (tracking application lifecycle events)