### PR TITLE
(feature) add ability to read anonymous id from Segment client library

### DIFF
--- a/android/src/main/java/com/smore/RNSegmentIOAnalytics/RNSegmentIOAnalyticsModule.java
+++ b/android/src/main/java/com/smore/RNSegmentIOAnalytics/RNSegmentIOAnalyticsModule.java
@@ -1,5 +1,6 @@
 package com.smore.RNSegmentIOAnalytics;
 
+import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
@@ -142,6 +143,14 @@ public class RNSegmentIOAnalyticsModule extends ReactContextBaseJavaModule {
   @ReactMethod
   public void enable() {
     mEnabled = true;
+  }
+
+  /*
+    https://segment.com/docs/libraries/android/#anonymousid
+   */
+  @ReactMethod
+  public void getAnonymousId(Promise promise) {
+    promise.resolve(mAnalytics.getAnalyticsContext().traits().anonymousId());
   }
 
   private Properties toProperties (ReadableMap map) {

--- a/android/src/main/java/com/smore/RNSegmentIOAnalytics/RNSegmentIOAnalyticsModule.java
+++ b/android/src/main/java/com/smore/RNSegmentIOAnalytics/RNSegmentIOAnalyticsModule.java
@@ -17,6 +17,7 @@ import android.util.Log;
 import android.content.Context;
 
 public class RNSegmentIOAnalyticsModule extends ReactContextBaseJavaModule {
+  private static final String NOT_INITIALIZED = "Segment context not initialized";
   private static Analytics mAnalytics = null;
   private Boolean mEnabled = true;
   private Boolean mDebug = false;
@@ -150,7 +151,11 @@ public class RNSegmentIOAnalyticsModule extends ReactContextBaseJavaModule {
    */
   @ReactMethod
   public void getAnonymousId(Promise promise) {
-    promise.resolve(mAnalytics.getAnalyticsContext().traits().anonymousId());
+    try {
+      promise.resolve(mAnalytics.getAnalyticsContext().traits().anonymousId());
+    } catch (NullPointerException e) {
+      promise.reject(NOT_INITIALIZED, e);
+    }
   }
 
   private Properties toProperties (ReadableMap map) {

--- a/index.js
+++ b/index.js
@@ -100,4 +100,12 @@ export default {
     enable: function () {
         NativeRNSegmentIOAnalytics.enable()
     },
+
+    /*
+     * https://segment.com/docs/libraries/ios/#anonymousid
+     * https://segment.com/docs/libraries/android/#anonymousid
+     */
+    getAnonymousId: function() {
+        return NativeRNSegmentIOAnalytics.getAnonymousId();
+    },
 }

--- a/ios/RNAnalytics/RNSegmentIOAnalytics.m
+++ b/ios/RNAnalytics/RNSegmentIOAnalytics.m
@@ -84,4 +84,11 @@ RCT_EXPORT_METHOD(enable) {
     [[SEGAnalytics sharedAnalytics] enable];
 }
 
+/*
+ https://segment.com/docs/libraries/ios/#anonymousid
+ */
+RCT_EXPORT_METHOD(getAnonymousId:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
+    resolve([[SEGAnalytics sharedAnalytics] getAnonymousId]);
+}
+
 @end


### PR DESCRIPTION
## Link to story (or tech task)

https://app.clubhouse.io/everymed/story/9233/update-insurance-button-is-confusing-in-settings

## Description

Add `getAnonymousId` function. We need anonymous id from Segment to avoid race condition between aliasing in Segment and sending push token directly to Mixpanel.